### PR TITLE
Feature/query

### DIFF
--- a/entis/CMakeLists.txt
+++ b/entis/CMakeLists.txt
@@ -9,7 +9,8 @@ target_sources(
     ${CMAKE_CURRENT_SOURCE_DIR}/include/entis/registry.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/entis/types.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/entis/component_manager.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/entis/error.h)
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/entis/error.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/entis/type_list.h)
 
 # It should use C++17.
 target_compile_features(

--- a/entis/include/entis/registry.h
+++ b/entis/include/entis/registry.h
@@ -1,6 +1,7 @@
 #ifndef REGISTRY_H
 #define REGISTRY_H
 
+#include <tuple>
 #include <vector>
 #include <memory>
 #include <utility>
@@ -11,10 +12,11 @@
 
 #include "types.h"
 #include "config.h"
+#include "type_list.h"
 #include "sparse_set.h"
 
 namespace entis
-{   
+{
     /**
      * Manages all the entities with their components by
      * providing a centralized interface for:
@@ -94,7 +96,7 @@ namespace entis
          * @returns true if the entity has a component T, false otherwise.
          */
         template <typename T>
-        bool has_component(const id_t entity)
+        bool has_component(const id_t entity) const
         {
             ComponentManager<T> manager = get_component_manager<T>();
 
@@ -112,7 +114,7 @@ namespace entis
          * and an empty optional otherwise.
          */
         template <typename T>
-        Component<T> get_component(const id_t entity)
+        Component<T> get_component(const id_t entity) const
         {
             Component<T> component{};
 
@@ -198,7 +200,7 @@ namespace entis
          * @return a list of entities that have a component T.
          */
         template<typename T>
-        std::vector<id_t> entities_with_component()
+        std::vector<id_t> entities_with_component() const
         {
             ComponentManager<T> manager = get_component_manager<T>();
 
@@ -216,9 +218,55 @@ namespace entis
             return entities;
         }
 
+        /**
+         * Get all the specified components of an entity if any.
+         * 
+         * @tparam Components all the components of the specified 
+         * entity that we want to retrieve.
+         * 
+         * @param entity the entity whose components we want to retieve.
+         * 
+         * @returns a tuple of optionals of references to the specified types.
+         * (e.g. tuple<optional<reference_wrapp<int>, optional<reference_wrapp<string>>).
+         */
+        template <typename... Components>
+        auto get_components(const id_t entity) const
+        {
+            return std::make_tuple(get_component<Components>(entity) ...);
+        }
+
+        template <typename WithComponents, typename WithoutComponents = typing::type_list_t<>>
+        QueryResult<WithComponents> query() const
+        {
+            // This vectors should be already sorted as the entity array appends values
+            // incrementally (e.g. 0, 1, 2, 3, etc.). Also, note that when killing 
+            // an entity the entity array is not sorted anymore but, since they don't
+            // have any component, the evaluation will always be false thus leaving
+            // only sorted results.
+            std::vector<id_t> desired_entities = with_components<WithComponents>();
+            std::vector<id_t> undesirable_entities = with_components<WithoutComponents>();
+
+            std::vector<id_t> required_entities{};
+
+            // leave only the desired entities.
+            std::set_difference(desired_entities.begin(), desired_entities.end(),
+                                undesirable_entities.begin(), undesirable_entities.end(),
+                                std::inserter(required_entities, required_entities.begin()));
+
+            QueryResult<WithComponents> result{};
+
+            std::transform(required_entities.begin(), required_entities.end(), std::back_inserter(result),
+            [this](const id_t entity)
+            {
+                return TypeListHelper<WithComponents>::convert_and_unwrapp(*this, entity);
+            });
+
+            return result;
+        }
+
     private:
 
-        id_t current_;
+        id_t current_; // last deleted entity (mainly used on implicit list).
         std::vector<id_t> entities_;
         std::unordered_map<std::string, std::shared_ptr<IComponentManager>> component_managers_;
 
@@ -285,7 +333,7 @@ namespace entis
          * if no manager has been created the pointer is empty.
          */
         template <typename T>
-        inline ComponentManager<T> get_component_manager()
+        inline ComponentManager<T> get_component_manager() const
         {
             ComponentManager<T> sparse_set{};
 
@@ -316,6 +364,90 @@ namespace entis
 
             return std::static_pointer_cast<SparseSet<T>>(component_managers_.at(type_name));
         }
+
+        /**
+         * Get all entities that have all the components on a type_list_t.
+         * 
+         * @tparam Components a type_list_t declaration that contain the expected components.
+         * 
+         */
+        template <typename Components>
+        inline std::vector<id_t> with_components() const
+        {
+            std::vector<id_t> result{};
+
+            if(!typing::is_empty<Components>::value)
+            {
+                std::copy_if(entities_.begin(), entities_.end(), std::back_inserter(result),
+                [this](const id_t entity)
+                {
+                    return TypeListHelper<Components>::has_components(*this, entity);
+                });
+            }
+
+            return result;
+        }
+
+        /**
+         * Abstract class used to apply registry functions on a type_list_t.
+         * 
+         * @tparam List a type_list_t definition.
+         */
+        template <typename List>
+        class TypeListHelper
+        {
+        public:
+            /**
+             * Create a tuple containing references to the types specified on a type_list_t. 
+             * For example: 
+             * 
+             * type_list_t<int, string> -> 
+             * tuple<reference_wrapper<int>, reference_wrapper<string>>
+             * 
+             * @tparam List a type_list_t definition.
+             * 
+             * @param registry a registry instance used to get component instances.
+             * @param entity an entity whose components we want to retrieve.
+             * 
+             * @returns a tuple of reference wrappers to the specified types.
+             */
+            static auto convert_and_unwrapp(const Registry& registry, const id_t entity);
+
+            /**
+             * Check if an entity has all components specified on a type_list_t.
+             * 
+             * @tparam List a type_list_t definition.
+             * 
+             * @param registry a registry instance used to get check if an 
+             * entity has some components.
+             * @param entity the entity that we will test.
+             * 
+             * @returns true if the specified entity has all the specified components and
+             * false otherwise.
+             */
+            static bool has_components(const Registry& registry, const id_t entity);
+        };
+
+        /**
+         * Specialization used to convert a type_list_t into a parameter pack. 
+         * 
+         * @tparam List parameter pack containing the list of types specified on
+         * a type_list_t.
+         */
+        template <typename... List>
+        class TypeListHelper<typing::type_list_t<List...>>
+        {
+        public:
+            static auto convert_and_unwrapp(const Registry& registry, const id_t entity)
+            {
+                return std::make_tuple(registry.get_component<List>(entity).value() ...);
+            }
+
+            static bool has_components(const Registry& registry, const id_t entity)
+            {
+                return (registry.has_component<List>(entity) && ...);
+            }
+        };
     };
 }
 

--- a/entis/include/entis/registry.h
+++ b/entis/include/entis/registry.h
@@ -235,6 +235,20 @@ namespace entis
             return std::make_tuple(get_component<Components>(entity) ...);
         }
 
+        /**
+         * Get the specified components of all the entities that satisfy the query params,
+         * this is, the list of components that the entities must have and the ones it
+         * mustn't have.
+         * 
+         * @tparam WithComponents a type_list_t declaration containing the types of the
+         * components that the entities must have.
+         * 
+         * @tparam WithoutComponents a type_list_t declaration containing the types of the
+         * components that the entities mustn't have.
+         * 
+         * @return a vector of tuples of references to the specified components of the entities
+         * that satisfy the query.
+         */
         template <typename WithComponents, typename WithoutComponents = typing::type_list_t<>>
         QueryResult<WithComponents> query() const
         {
@@ -370,6 +384,8 @@ namespace entis
          * 
          * @tparam Components a type_list_t declaration that contain the expected components.
          * 
+         * @returns a sorted vector of entities where each of them is guaranteed to have
+         * all the components specified on the type_list_t.
          */
         template <typename Components>
         inline std::vector<id_t> with_components() const

--- a/entis/include/entis/type_list.h
+++ b/entis/include/entis/type_list.h
@@ -1,0 +1,388 @@
+#ifndef TYPE_LIST_H
+#define TYPE_LIST_H
+
+#include <utility>
+
+namespace entis
+{
+    namespace typing
+    {
+        /**
+         * T data structure used to store a number of types.
+         * 
+         * @tparam Types a packed list of types (e.g. <int, char, float>).
+         */ 
+        template <typename... Types>
+        class type_list_t
+        {
+        };
+
+        /**
+         * T type trait used to get the number of elements of a 
+         * type_list_t.
+         * 
+         * @tparam List default type implementation.
+         */
+        template <typename List>
+        class type_list_size
+        {
+        public:
+            static constexpr size_t value = 0;
+        };
+
+        /**
+         * type_list_t type_list_size trait implementation.
+         * 
+         * @tparam List a packed list of types (e.g. <int, char, double>).
+         */
+        template <typename... List>
+        class type_list_size<type_list_t<List...>>
+        {
+        public:
+            static constexpr size_t value = sizeof...(List);
+        };
+
+        /**
+         * T type trait used for knowing if a container is empty
+         * 
+         * @tparam List default type implementation. 
+         */
+        template <typename List>
+        class is_empty
+        {
+        public:
+            static constexpr bool value = false;
+        };
+
+        /**
+         * type_list_t is_empty type trait implementation.
+         */
+        template <>
+        class is_empty<type_list_t<>>
+        {
+        public:
+            static constexpr bool value = true;
+        };
+
+        /**
+         * Checks if two type_list_t are the same based on the sequence of
+         * types it contains.
+         * 
+         * @tparam T the first type_list_t to be used on the comparison.
+         * @tparam U the second type_list_t to be used on the comparison.
+         * 
+         * @return true if both type_list_t contain the exact same sequence of types
+         * (the same types, the same order and number of types).
+         */
+        template <typename T, typename U>
+        inline constexpr bool is_equal()
+        {
+            return typeid(T) == typeid(U);
+        }
+
+        /**
+         * Get the number of types on a type_list_t.
+         * 
+         * @tparam T the type_list_t whose size we want.
+         * 
+         * @returns the number of types on a type_list_t.
+         */
+        template <typename T>
+        inline constexpr size_t size()
+        {
+            return type_list_size<T>::value;
+        }
+
+
+        template <typename List>
+        class front_t;
+
+        template <>
+        class front_t<type_list_t<>>
+        {
+        public:
+            using Type = type_list_t<>;
+        };
+
+        template <typename Head, typename... Tail>
+        class front_t<type_list_t<Head, Tail...>>
+        {
+        public:
+            using Type = Head;
+        };
+
+        /**
+         * Get the first type on a type_list_t.
+         * 
+         * @tparam List a type_list_t definition.
+         * 
+         * @returns the first element on a type_list_t
+         * (e.g. <int, char, double> -> int).
+         */
+        template <typename List>
+        using front = typename front_t<List>::Type;
+
+
+        template <typename List, typename NewType>
+        class push_back_t;
+
+        template <typename... List, typename NewType>
+        class push_back_t<type_list_t<List...>, NewType>
+        {
+        public:
+            using Type = type_list_t<List..., NewType>;
+        };
+
+        /**
+         * Create a new type_list_t with a new type added on its tail 
+         * (last position).
+         * 
+         * @tparam List a type_list_t definition that will be used as a base
+         * for the new type_list_t.
+         * 
+         * @tparam NewType the type to append to the new type_list_t.
+         * 
+         * @returns a new type_list_t with the elements of List and NewType
+         * added on the last position (e.g. <int, char>, double -> <int, char, double>).
+         */
+        template <typename List, typename NewType>
+        using push_back = typename push_back_t<List, NewType>::Type;
+
+
+        template <typename List, typename NewType>
+        class push_front_t;
+
+        template <typename... List, typename NewType>
+        class push_front_t<type_list_t<List...>, NewType>
+        {
+        public:
+            using Type = type_list_t<NewType, List...>;
+        };
+
+        /**
+         * Creates a new type_list_t with a type added at the beginning
+         * 
+         * @tparam List a type_list_t definition that will be used as a base
+         * for the new type_list_t.
+         * 
+         * @tparam NewType the type to append to the new type_list_t.
+         * 
+         * @returns a new type_list_t with NewType at the beginning
+         * (e.g. <char, double>, int -> <int, char, double>).
+         */ 
+        template <typename List, typename NewType>
+        using push_front = typename push_front_t<List, NewType>::Type;
+
+
+        template <typename List>
+        class pop_front_t;
+
+        template <>
+        class pop_front_t<type_list_t<>>
+        {
+        public:
+            using Type = type_list_t<>;
+        };
+
+        template <typename Head, typename... Tail>
+        class pop_front_t<type_list_t<Head, Tail...>>
+        {
+        public:
+            using Type = type_list_t<Tail...>;
+        };
+
+        /**
+         * Creates a new type_list_t with a type added at the beginning
+         * 
+         * @tparam List a type_list_t definition that will be used as a base
+         * for the new type_list_t.
+         * 
+         * @tparam NewType the type to append to the new type_list_t.
+         * 
+         * @returns a new type_list_t with NewType at the beginning
+         * (e.g. <char, double>, int -> <int, char, double>).
+         */
+        template <typename List>
+        using pop_front = typename pop_front_t<List>::Type;
+
+
+        template <typename List, size_t Index>
+        class at_t : public at_t<pop_front<List>, Index - 1>
+        {
+        };
+
+        template <typename List>
+        class at_t<List, 0> : public front_t<List>
+        {
+        };
+
+        /**
+         * Get the type at a certain index in a type_list_t.
+         * 
+         * @tparam List the list whose type we want to retrieve.
+         * 
+         * @tparam Index a positive integer that will be used as the index
+         * for retrieving the type.
+         * 
+         * @returns the type at index Index (e.g. <int, char, double>, 1 -> char).
+         */
+        template <typename List, size_t Index>
+        using at = typename at_t<List, Index>::Type;
+
+
+        template <typename List>
+        class top_t;
+
+        template <typename... List>
+        class top_t<type_list_t<List...>>
+        {
+        public:
+            using Type = at<type_list_t<List...>, sizeof...(List) - 1>;
+        };
+
+        /**
+         * Get the last type on a type_list_t.
+         * 
+         * @tparam List the type_list_t whose last element we want to retrieve.
+         * 
+         * @returns the last element on a type_list_t (e.g. <char, int> -> int).
+         */
+        template <typename List>
+        using top = typename top_t<List>::Type;
+
+
+        template <typename List, bool IsLast = is_empty<List>::value>
+        class reverse_t;
+
+        /**
+         * Create a new type_list_t with the elements of the original type_list_t
+         * reversed.
+         * 
+         * @tparam List the type_list_t whose elements we want to reverse.
+         * 
+         * @returns a new type_list_t with the elements of the original type_list_t
+         * reversed (e.g. <char, int> -> <int, char>).
+         */
+        template <typename List>
+        using reverse = typename reverse_t<List>::Type;
+
+        template <typename List>
+        class reverse_t<List, false> : public push_back_t<reverse<pop_front<List>>, front<List>>
+        {
+
+        };
+
+        template <typename List>
+        class reverse_t<List, true>
+        {
+        public:
+            using Type = List;
+        };
+
+        /**
+         * Create a new type_list_t without its last element.
+         * 
+         * @tparam List is a type_list_t definition.
+         * 
+         * @returns a new type_list_t without its last element
+         * (e.g. <int, char double> -> <int, char>)
+         */
+        template<typename List>
+        using pop_back = reverse<pop_front<reverse<List>>>;
+
+
+        template<typename T, template <typename...> typename U>
+        struct cast_t;
+
+        template<template<typename...> typename T, typename... V, template <typename...> typename U>
+        struct cast_t<T<V...>, U> {
+            using Type = U<V...>;
+        };
+
+        /**
+         * Use the types on a type_list_t to create a new container.
+         * (e.g. std::tuple)
+         * 
+         * @tparam T the type_list_t whose types we want.        
+         * @tparam U the new container we want to create using the type_list_t.
+         * 
+         * @returns the specified container U using the types on type_list_t.
+         * (e.g. type_list_t<int, char double> -> std::tuple<int, char double>)
+         */
+        template<class T, template<typename...> typename U>
+        using cast = typename cast_t<T, U>::Type;
+
+
+        template <typename T>
+        class add_optional_t
+        {
+        public:
+            using Type = std::optional<T>; 
+        };
+
+        /**
+         * Wrapps the supplied type into a optional.
+         * 
+         * @tparam T the type we want to wrap.
+         * 
+         * 
+         * @returns an optional of type T (e.g. <double> -> std::optional<double>).
+         */
+        template <typename T>
+        using add_optional = typename add_optional_t<T>::Type;
+
+
+        template <typename T>
+        class add_reference_wrapper_t
+        {
+        public:
+            using Type = std::reference_wrapper<const T>; 
+        };
+
+        /**
+         * Wrapps the supplied type into a const reference wrapper.
+         * 
+         * @tparam T the type we want to wrap.
+         * 
+         * 
+         * @returns an optional of type T (e.g. <double> -> std::reference_wrapper<double>).
+         */
+        template <typename T>
+        using add_reference_wrapper = typename add_reference_wrapper_t<T>::Type;
+
+
+        template <typename List, template<typename T> class MetaFun, bool Empty = is_empty<List>::value>
+        class transform_t;
+
+        template <typename List, template<typename T> class MetaFun>
+        class transform_t<List, MetaFun, false> 
+            : public push_front_t<typename transform_t<pop_front<List>,
+                                   MetaFun>::Type,
+                                  MetaFun<front<List>>>
+        {
+        };
+
+        template <typename List, template<typename T> class MetaFun>
+        class transform_t<List, MetaFun, true>
+        {
+        public:
+            using Type = List;
+        };
+
+        /**
+         * Applies a MetaFun to all the types on a type_list_t.
+         * 
+         * @tparam List a type_list_t.
+         * @tparam MetaFun a meta function such as add_optional that
+         * will be applied to all the types on a type_list_t.
+         * 
+         * @return a new type_list_t with the result of applying the
+         * MetaFun to all the previous types (e.g. <double, int>, add_optional ->
+         * <std::optional<double>, std::optional<int>>).
+         */
+        template <typename List, template<typename T> class MetaFun>
+        using transform = typename transform_t<List, MetaFun>::Type;
+    }
+}
+
+#endif

--- a/entis/include/entis/type_list.h
+++ b/entis/include/entis/type_list.h
@@ -114,7 +114,7 @@ namespace entis
         /**
          * Get the first type on a type_list_t.
          * 
-         * @tparam List a type_list_t definition.
+         * @tparam List a type_list_t declaration.
          * 
          * @returns the first element on a type_list_t
          * (e.g. <int, char, double> -> int).
@@ -137,7 +137,7 @@ namespace entis
          * Create a new type_list_t with a new type added on its tail 
          * (last position).
          * 
-         * @tparam List a type_list_t definition that will be used as a base
+         * @tparam List a type_list_t declaration that will be used as a base
          * for the new type_list_t.
          * 
          * @tparam NewType the type to append to the new type_list_t.
@@ -162,7 +162,7 @@ namespace entis
         /**
          * Creates a new type_list_t with a type added at the beginning
          * 
-         * @tparam List a type_list_t definition that will be used as a base
+         * @tparam List a type_list_t declaration that will be used as a base
          * for the new type_list_t.
          * 
          * @tparam NewType the type to append to the new type_list_t.
@@ -194,7 +194,7 @@ namespace entis
         /**
          * Creates a new type_list_t with a type added at the beginning
          * 
-         * @tparam List a type_list_t definition that will be used as a base
+         * @tparam List a type_list_t declaration that will be used as a base
          * for the new type_list_t.
          * 
          * @tparam NewType the type to append to the new type_list_t.
@@ -282,7 +282,7 @@ namespace entis
         /**
          * Create a new type_list_t without its last element.
          * 
-         * @tparam List is a type_list_t definition.
+         * @tparam List is a type_list_t declaration.
          * 
          * @returns a new type_list_t without its last element
          * (e.g. <int, char double> -> <int, char>)

--- a/entis/include/entis/types.h
+++ b/entis/include/entis/types.h
@@ -1,22 +1,30 @@
 #ifndef ENTIS_TYPES_H
 #define ENTIS_TYPES_H
 
+#include <tuple>
 #include <memory>
 #include <utility>
 #include <optional>
 
+#include "type_list.h"
 #include "sparse_set.h"
 #include "error.h"
 
 namespace entis
 {
+    using BindResult = std::optional<error::BindError>;
+
     template <typename T>
     using ComponentManager = std::shared_ptr<SparseSet<T>>;
 
     template <typename T>
     using Component = std::optional<std::reference_wrapper<const T>>;
 
-    using BindResult = std::optional<error::BindError>;
+    template <typename T>
+    using Components = typing::cast<typing::transform<
+                                        typing::transform<T, typing::add_reference_wrapper>, 
+                                        typing::add_optional>, 
+                                    std::tuple>;
 }
 
 #endif

--- a/entis/include/entis/types.h
+++ b/entis/include/entis/types.h
@@ -12,19 +12,47 @@
 
 namespace entis
 {
+    /**
+     * An optional that could possibly have a BindError.
+     */
     using BindResult = std::optional<error::BindError>;
 
+    /**
+     * A pointer to a SparseSet that manages the type T.
+     * 
+     * @tparam T the type that the SparseSet is managing.
+     */
     template <typename T>
     using ComponentManager = std::shared_ptr<SparseSet<T>>;
 
+    /**
+     * An optional that could contain a reference to the specified
+     * type T.
+     * 
+     * @tparam T the type of the component.
+     */
     template <typename T>
     using Component = std::optional<std::reference_wrapper<const T>>;
 
-    template <typename T>
+    /**
+     * A tuple containig optionals to references to the types specified on a
+     * type_list_t.
+     * 
+     * @tparam List a type_list_t declaration containing the types that we want.
+     */ 
+    template <typename List>
     using Components = typing::cast<typing::transform<
-                                        typing::transform<T, typing::add_reference_wrapper>, 
+                                        typing::transform<List, typing::add_reference_wrapper>, 
                                         typing::add_optional>, 
                                     std::tuple>;
+    /**
+     * A tuple containig references to the types specified on a
+     * type_list_t if any.
+     * 
+     * @tparam List a type_list_t declaration containing the types that we want.
+     */ 
+    template <typename List>
+    using QueryResult = std::vector<typing::cast<typing::transform<List, typing::add_reference_wrapper>, std::tuple>>;
 }
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(
     main.cpp 
     sparse_set_test.cpp
     registry_test.cpp
+    type_list_test.cpp
 )
 
 target_link_libraries(

--- a/test/type_list_test.cpp
+++ b/test/type_list_test.cpp
@@ -1,0 +1,128 @@
+#include <tuple>
+#include <optional>
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <entis/type_list.h>
+
+TEST(TypeListTest, CanGetSizeOfTypeList)
+{
+    using test_A = entis::typing::type_list_t<uint32_t, float, double>;
+    using test_B = entis::typing::type_list_t<uint32_t, float>;
+    using test_C = entis::typing::type_list_t<>;
+
+    ASSERT_EQ(entis::typing::size<test_A>(), 3);
+    ASSERT_EQ(entis::typing::size<test_B>(), 2);
+    ASSERT_EQ(entis::typing::size<test_C>(), 0);
+}
+
+TEST(TypeListTest, CanReverse)
+{
+    using expected = entis::typing::type_list_t<double, float, uint32_t>;
+    using test = entis::typing::type_list_t<uint32_t, float, double>;
+
+    using result = entis::typing::reverse<test>;
+
+    ASSERT_TRUE((entis::typing::is_equal<result, expected>()));
+}
+
+TEST(TypeListTest, CanPushFront)
+{
+    using expected = entis::typing::type_list_t<double, uint32_t, float>;
+    using test = entis::typing::type_list_t<uint32_t, float>;
+
+    using result = entis::typing::push_front<test, double>;
+
+    ASSERT_TRUE((entis::typing::is_equal<result, expected>()));
+}
+
+TEST(TypeListTest, CanPushBack)
+{
+    using expected = entis::typing::type_list_t<double, uint32_t, float>;
+    using test = entis::typing::type_list_t<double, uint32_t>;
+
+    using result = entis::typing::push_back<test, float>;
+
+    ASSERT_TRUE((entis::typing::is_equal<result, expected>()));
+}
+
+TEST(TypeListTest, CanPopFront)
+{
+    using expected = entis::typing::type_list_t<float>;
+    using test = entis::typing::type_list_t<uint32_t, float>;
+
+    using result = entis::typing::pop_front<test>;
+
+    ASSERT_TRUE((entis::typing::is_equal<result, expected>()));
+}
+
+TEST(TypeListTest, CanPopBack)
+{
+    using expected = entis::typing::type_list_t<uint32_t>;
+    using test = entis::typing::type_list_t<uint32_t, float>;
+
+    using result = entis::typing::pop_back<test>;
+
+    ASSERT_TRUE((entis::typing::is_equal<result, expected>()));
+}
+
+TEST(TypeListTest, CanGetFrontType)
+{
+    using test = entis::typing::type_list_t<uint32_t, float>;
+    using result = entis::typing::front<test>;
+ 
+    ASSERT_TRUE((entis::typing::is_equal<result, uint32_t>()));
+}
+
+TEST(TypeListTest, CanGetTopType)
+{
+    using test = entis::typing::type_list_t<uint32_t, float>;
+    using result = entis::typing::top<test>;
+ 
+    ASSERT_TRUE((entis::typing::is_equal<result, float>()));
+}
+
+TEST(TypeListTest, CanGetTypeAtIndex)
+{
+    using test = entis::typing::type_list_t<double, uint32_t, float>;
+
+    ASSERT_TRUE((entis::typing::is_equal<entis::typing::at<test, 0>, double>()));
+    ASSERT_TRUE((entis::typing::is_equal<entis::typing::at<test, 1>, uint32_t>()));
+    ASSERT_TRUE((entis::typing::is_equal<entis::typing::at<test, 2>, float>()));
+}
+
+TEST(TypeListTest, CanConvertToTuple)
+{
+    using test = entis::typing::type_list_t<double, uint32_t, float>;
+
+    const std::tuple<double, uint32_t, float> expected{};
+
+    const entis::typing::cast<test, std::tuple> result{};
+
+    ASSERT_EQ(typeid(expected), typeid(result));
+}
+
+TEST(TypeListTest, CanAddOptional)
+{
+    using test = double;
+
+    using expected = std::optional<double>;
+
+    using result = entis::typing::add_optional<test>;
+
+    ASSERT_TRUE((entis::typing::is_equal<result, expected>()));
+}
+
+TEST(TypeListTest, CanTransformList)
+{
+    using test = entis::typing::type_list_t<double, uint32_t, float>;
+
+    using expected = entis::typing::type_list_t<std::optional<double>,
+                                                std::optional<uint32_t>,
+                                                std::optional<float>>;
+
+    using result = entis::typing::transform<test, entis::typing::add_optional>;
+
+    ASSERT_TRUE((entis::typing::is_equal<result, expected>()));
+}


### PR DESCRIPTION
Enable Registry to query components of entities, this is, specify what components an entity must have and mustn't have and retrieve the specified components of all the entities that satisfy the query. This implementation includes:
+ A small metaprogramming library so we can make "complex" operations on a list of types.
+ The implementation of the query function.
+ The implementation of the get_components function.